### PR TITLE
fix: noImplicitReturns error TypeScript

### DIFF
--- a/src/kenteken-check-nl-class.ts
+++ b/src/kenteken-check-nl-class.ts
@@ -58,6 +58,8 @@ export class KentekenCheck {
                 this.index = i;
                 return true;
             }
+
+            return false;
         });
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */


### PR DESCRIPTION
When running the typescript commands an error occurs when flag noImplicitReturns is set true. This pull-request fixes the issue.